### PR TITLE
NewGraphite: change to deferred connect strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ func main() {
 
 	interval := 30 * time.Second
 	timeout := 3 * time.Second
-	g, err := g2g.NewGraphite("graphite-server:2003", interval, timeout)
-	if err != nil {
-		// do something
-	}
+	g := g2g.NewGraphite("graphite-server:2003", interval, timeout)
 	g.Register("foo.service.records.loaded", loadedRecords)
 
 	// ...

--- a/g2g.go
+++ b/g2g.go
@@ -29,8 +29,9 @@ type namedVar struct {
 	v    expvar.Var
 }
 
-// NewGraphite returns a Graphite structure with an open and working
-// connection, but no active/registered variables being published.
+// NewGraphite returns a Graphite structure with no active/registered
+// variables being published.  The connection setup is lazy, e.g. it is
+// done at the first metric submission.
 // Endpoint should be of the format "host:port", eg. "stats:2003".
 // Interval is the (best-effort) minimum duration between (sequential)
 // publishments of Registered expvars. Timeout is per-publish-action.
@@ -43,9 +44,6 @@ func NewGraphite(endpoint string, interval, timeout time.Duration) (*Graphite, e
 		vars:          map[string]expvar.Var{},
 		registrations: make(chan namedVar),
 		shutdown:      make(chan chan bool),
-	}
-	if err := g.reconnect(); err != nil {
-		return nil, err
 	}
 	go g.loop()
 	return g, nil

--- a/g2g.go
+++ b/g2g.go
@@ -35,7 +35,7 @@ type namedVar struct {
 // Endpoint should be of the format "host:port", eg. "stats:2003".
 // Interval is the (best-effort) minimum duration between (sequential)
 // publishments of Registered expvars. Timeout is per-publish-action.
-func NewGraphite(endpoint string, interval, timeout time.Duration) (*Graphite, error) {
+func NewGraphite(endpoint string, interval, timeout time.Duration) *Graphite {
 	g := &Graphite{
 		endpoint:      endpoint,
 		interval:      interval,
@@ -46,7 +46,7 @@ func NewGraphite(endpoint string, interval, timeout time.Duration) (*Graphite, e
 		shutdown:      make(chan chan bool),
 	}
 	go g.loop()
-	return g, nil
+	return g
 }
 
 // Register registers an expvar under the given name. (Roughly) every

--- a/g2g_test.go
+++ b/g2g_test.go
@@ -16,21 +16,9 @@ func TestPublish(t *testing.T) {
 	port := 2003
 	mock := NewMockGraphite(t, port)
 	d := 25 * time.Millisecond
-	attempts, maxAttempts := 0, 3
 	var g *Graphite
-	for {
-		attempts++
-		var err error
-		g, err = NewGraphite(fmt.Sprintf("localhost:%d", port), d, d)
-		if err == nil || attempts > maxAttempts {
-			break
-		}
-		t.Logf("(%d/%d) %s", attempts, maxAttempts, err)
-		time.Sleep(d)
-	}
-	if g == nil {
-		t.Fatalf("Mock Graphite server never came up")
-	}
+	g = NewGraphite(fmt.Sprintf("localhost:%d", port), d, d)
+	time.Sleep(d)
 
 	// register, wait, check
 	i := expvar.NewInt("i")


### PR DESCRIPTION
Defer creating a connection until later.  This results in not failing to
create a new graphite object when the connection cannot be made.

In our setup, we see services failing to startup because we cannot setup
g2g.  This is due to the graphite connection failing to be setup,
because the service is down, or a network issue of any kind.
Since each metric submission does a reconnect of the connection (thereby
dealing with the connection being broken somehow during the lifetime of
the graphite object) it is ok to skip the initial connection attempt
during object creation.  It in this case makes the code more resistant
against upstream graphite service failures.