### PR TITLE
Add support for specifying network type

### DIFF
--- a/g2g.go
+++ b/g2g.go
@@ -34,10 +34,10 @@ type namedVar struct {
 	v    expvar.Var
 }
 
-// SplitEndpoint splits the provided endpoint string into its network and address
+// splitEndpoint splits the provided endpoint string into its network and address
 // parts. It will default to 'tcp' network to ensure backward compatibility when
 // the endpoint is not prefixed with a network:// part.
-func SplitEndpoint(endpoint string) (string, string) {
+func splitEndpoint(endpoint string) (string, string) {
 	network := "tcp"
 	idx := strings.Index(endpoint, NetworkSeparator)
 	if idx != -1 {
@@ -53,7 +53,7 @@ func SplitEndpoint(endpoint string) (string, string) {
 // Interval is the (best-effort) minimum duration between (sequential)
 // publishments of Registered expvars. Timeout is per-publish-action.
 func NewGraphite(endpoint string, interval, timeout time.Duration) *Graphite {
-	network, endpoint := SplitEndpoint(endpoint)
+	network, endpoint := splitEndpoint(endpoint)
 	g := &Graphite{
 		network:       network,
 		endpoint:      endpoint,

--- a/g2g.go
+++ b/g2g.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	NetworkSeparator = "://"
+	networkSeparator = "://"
 )
 
 // Graphite represents a Graphite server. You Register expvars
@@ -39,9 +39,9 @@ type namedVar struct {
 // the endpoint is not prefixed with a network:// part.
 func splitEndpoint(endpoint string) (string, string) {
 	network := "tcp"
-	idx := strings.Index(endpoint, NetworkSeparator)
+	idx := strings.Index(endpoint, networkSeparator)
 	if idx != -1 {
-		network, endpoint = endpoint[:idx], endpoint[idx+len(NetworkSeparator):]
+		network, endpoint = endpoint[:idx], endpoint[idx+len(networkSeparator):]
 	}
 	return network, endpoint
 }

--- a/g2g.go
+++ b/g2g.go
@@ -10,10 +10,15 @@ import (
 	"time"
 )
 
+const (
+	NetworkSeparator = "://"
+)
+
 // Graphite represents a Graphite server. You Register expvars
 // in this struct, which will be published to the server on a
 // regular interval.
 type Graphite struct {
+	network       string
 	endpoint      string
 	interval      time.Duration
 	timeout       time.Duration
@@ -29,14 +34,28 @@ type namedVar struct {
 	v    expvar.Var
 }
 
+// SplitEndpoint splits the provided endpoint string into its network and address
+// parts. It will default to 'tcp' network to ensure backward compatibility when
+// the endpoint is not prefixed with a network:// part.
+func SplitEndpoint(endpoint string) (string, string) {
+	network := "tcp"
+	idx := strings.Index(endpoint, NetworkSeparator)
+	if idx != -1 {
+		network, endpoint = endpoint[:idx], endpoint[idx+len(NetworkSeparator):]
+	}
+	return network, endpoint
+}
+
 // NewGraphite returns a Graphite structure with no active/registered
 // variables being published.  The connection setup is lazy, e.g. it is
 // done at the first metric submission.
-// Endpoint should be of the format "host:port", eg. "stats:2003".
+// Endpoint should be of the format "network://host:port", eg. "tcp://stats:2003".
 // Interval is the (best-effort) minimum duration between (sequential)
 // publishments of Registered expvars. Timeout is per-publish-action.
 func NewGraphite(endpoint string, interval, timeout time.Duration) *Graphite {
+	network, endpoint := SplitEndpoint(endpoint)
 	g := &Graphite{
+		network:       network,
 		endpoint:      endpoint,
 		interval:      interval,
 		timeout:       timeout,
@@ -133,7 +152,7 @@ func (g *Graphite) postOne(name, value string) error {
 
 // reconnect attempts to (re-)establish a TCP connection to the Graphite server.
 func (g *Graphite) reconnect() error {
-	conn, err := net.Dial("tcp", g.endpoint)
+	conn, err := net.Dial(g.network, g.endpoint)
 	if err != nil {
 		return err
 	}

--- a/g2g_test.go
+++ b/g2g_test.go
@@ -2,7 +2,6 @@ package g2g
 
 import (
 	"expvar"
-	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -10,18 +9,20 @@ import (
 	"time"
 )
 
-func TestPublish(t *testing.T) {
+var i = expvar.NewInt("i")
 
+func TestPublish(t *testing.T) {
+	testPub(t, "localhost:2003", NewMockGraphite(t, "tcp://:2003"))
+	testPub(t, "unix:///tmp/test.sock", NewMockGraphite(t, "unix:///tmp/test.sock"))
+}
+
+func testPub(t *testing.T, address string, mock *MockGraphite) {
 	// setup
-	port := 2003
-	mock := NewMockGraphite(t, port)
 	d := 25 * time.Millisecond
 	var g *Graphite
-	g = NewGraphite(fmt.Sprintf("localhost:%d", port), d, d)
-	time.Sleep(d)
+	g = NewGraphite(address, d, d)
 
 	// register, wait, check
-	i := expvar.NewInt("i")
 	i.Set(34)
 	g.Register("test.foo.i", i)
 
@@ -84,22 +85,22 @@ func TestRoundFloat(t *testing.T) {
 //
 
 type MockGraphite struct {
-	t     *testing.T
-	port  int
-	count int
-	mtx   sync.Mutex
-	ln    net.Listener
-	done  chan bool
+	t       *testing.T
+	address string
+	count   int
+	mtx     sync.Mutex
+	ln      net.Listener
+	done    chan bool
 }
 
-func NewMockGraphite(t *testing.T, port int) *MockGraphite {
+func NewMockGraphite(t *testing.T, address string) *MockGraphite {
 	m := &MockGraphite{
-		t:     t,
-		port:  port,
-		count: 0,
-		mtx:   sync.Mutex{},
-		ln:    nil,
-		done:  make(chan bool, 1),
+		t:       t,
+		address: address,
+		count:   0,
+		mtx:     sync.Mutex{},
+		ln:      nil,
+		done:    make(chan bool, 1),
 	}
 	go m.loop()
 	return m
@@ -117,7 +118,8 @@ func (m *MockGraphite) Shutdown() {
 }
 
 func (m *MockGraphite) loop() {
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", m.port))
+	network, address := SplitEndpoint(m.address)
+	ln, err := net.Listen(network, address)
 	if err != nil {
 		panic(err)
 	}

--- a/g2g_test.go
+++ b/g2g_test.go
@@ -118,7 +118,7 @@ func (m *MockGraphite) Shutdown() {
 }
 
 func (m *MockGraphite) loop() {
-	network, address := SplitEndpoint(m.address)
+	network, address := splitEndpoint(m.address)
 	ln, err := net.Listen(network, address)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This is useful to have for several scenarios. In our infrastructure, we
are using mounted sockets within containers to send Graphite metrics to
the host os, which then forwards it to carbon relays.