### PR TITLE
Fix potential crashes in Graphite.Shutdown() and GraphiteMock.Shutdown()

### DIFF
--- a/g2g.go
+++ b/g2g.go
@@ -93,8 +93,10 @@ func (g *Graphite) loop() {
 		case <-ticker.C:
 			g.postAll()
 		case q := <-g.shutdown:
-			g.connection.Close()
-			g.connection = nil
+			if g.connection != nil {
+				g.connection.Close()
+				g.connection = nil
+			}
 			q <- true
 			return
 		}

--- a/g2g_test.go
+++ b/g2g_test.go
@@ -116,8 +116,10 @@ func (m *MockGraphite) Count() int {
 }
 
 func (m *MockGraphite) Shutdown() {
-	m.ln.Close()
-	<-m.done
+	if m.ln != nil {
+		m.ln.Close()
+		<-m.done
+	}
 }
 
 func (m *MockGraphite) loop() {


### PR DESCRIPTION
Both patches fix somewhat similar issues when Shutdown() is called before everything is properly initialised.

The crash in tests is very artificial and is unlikely to happen, so the fix is there mostly for correctness. Feel free to skip that commit if you think the patch is not useful.
The crash in Graphite.Shutdown(), however, is very real and was caught in production a couple of times.